### PR TITLE
Comply with a rule from ansible-lint 4.0.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,3 +20,7 @@
   package:
     name: '{{ item }}'
     state: present
+  register: package_installs
+  until: package_installs is success
+  retries: 10
+  delay: 2


### PR DESCRIPTION
Although the rule was removed in ansible-lint 4.1 after [debate on github](https://github.com/ansible/ansible-lint/issues/456), I think it makes sense to check for success and retry a couple of times when you download and install from the network (it is not a perfect world).

In my integration I have an extra rules directory for ansible-lint for [PackageHasRetryRule.py](https://github.com/ansible/ansible-lint/blob/v4.0.0/lib/ansiblelint/rules/PackageHasRetryRule.py). 

It reported:
```
[405] Remote package tasks should have a retry
andrewrothstein.unarchive-deps/tasks/main.yml:13
Task/Handler: install common pkgs...
```

This PR adds the retry behaviour.