### PR TITLE
Add support for the Linux Gentoo distribution

### DIFF
--- a/vars/Gentoo.yml
+++ b/vars/Gentoo.yml
@@ -1,0 +1,9 @@
+---
+unarchive_deps_all_pkgs:
+  - app-arch/bzip2
+  - app-arch/gzip
+  - app-arch/unzip
+unarchive_deps_tar_pkgs:
+  - app-arch/tar
+unarchive_deps_xz_pkgs:
+  - app-arch/xz-utils


### PR DESCRIPTION
Thank you for your collection on Ansible roles!

While using andrewrothstein.velero, I found that andrewrothstein.unarchive-deps doesn't support Gentoo. This change fixes andrewrothstein.unarchive-deps and thus andrewrothstein.velero for Gentoo.

Testing works against the https://hub.docker.com/r/gentoo/stage3-amd64 image. Looking at your .travis.yml, the following pulls the correct image if you want to add Gentoo to your Quay repo:

    dcb --upstreamgroup gentoo --upstreamapp stage3-amd64 --pullall --writeall --buildall --alltags latest --upstreamregistry registry.hub.docker.com