### PR TITLE
Update apt cache on Debian/Ubuntu

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,12 @@
       skip: true
       paths:
         - '{{ role_path }}/vars'
-
+        
+- name: update apt cache
+  apt:
+    update_cache: true
+  when: ansible_os_family == 'Debian'
+  
 - name: install unarchive module pkgs...
   become: '{{ unarchive_deps_privilege_escalation }}'
   become_user: '{{ unarchive_deps_privilege_escalation_user }}'


### PR DESCRIPTION
Otherwise it fails with the following error when run in fresh Docker containers:
```
TASK [andrewrothstein.unarchive-deps : install OS packages] ********************
fatal: [instance]: FAILED! => {"changed": false, "msg": "No package matching 'unzip' is available"}
```